### PR TITLE
retry generator + tests

### DIFF
--- a/retry/api.py
+++ b/retry/api.py
@@ -1,6 +1,7 @@
 import logging
 import random
 import time
+import types
 
 from functools import partial
 
@@ -51,7 +52,52 @@ def __retry_internal(f, exceptions=Exception, tries=-1, delay=0, max_delay=None,
                 _delay = min(_delay, max_delay)
 
 
-def retry(exceptions=Exception, tries=-1, delay=0, max_delay=None, backoff=1, jitter=0, logger=logging_logger):
+def __retry_internal_generator(f, exceptions=Exception, tries=-1, delay=0, max_delay=None, backoff=1, jitter=0,
+                               logger=logging_logger):
+    """
+    Iterate through a generator returned by a given function and retry from the start if it failed.
+
+    :param f: the function that returns a generator
+    :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
+    :param tries: the maximum number of attempts. default: -1 (infinite).
+    :param delay: initial delay between attempts. default: 0.
+    :param max_delay: the maximum value of delay. default: None (no limit).
+    :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
+    :param jitter: extra seconds added to delay between attempts. default: 0.
+                   fixed if a number, random if a range tuple (min, max)
+    :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
+                   default: retry.logging_logger. if None, logging is disabled.
+    :returns: the result of the f function.
+    """
+    _tries, _delay = tries, delay
+    while _tries:
+        try:
+            for x in f():
+                yield x
+            raise StopIteration
+        except StopIteration:
+            raise
+        except exceptions as e:
+            _tries -= 1
+            if not _tries:
+                raise
+
+            if logger is not None:
+                logger.warning('%s, retrying in %s seconds...', e, _delay)
+
+            time.sleep(_delay)
+            _delay *= backoff
+
+            if isinstance(jitter, tuple):
+                _delay += random.uniform(*jitter)
+            else:
+                _delay += jitter
+
+            if max_delay is not None:
+                _delay = min(_delay, max_delay)
+
+
+def retry(exceptions=Exception, tries=-1, delay=0, max_delay=None, backoff=1, jitter=0, logger=logging_logger, generator=False):
     """Returns a retry decorator.
 
     :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
@@ -63,6 +109,8 @@ def retry(exceptions=Exception, tries=-1, delay=0, max_delay=None, backoff=1, ji
                    fixed if a number, random if a range tuple (min, max)
     :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
                    default: retry.logging_logger. if None, logging is disabled.
+    :param generator: if True, assumes decorated function returns a generator and wraps
+                      it in a new generator. Will retry from start on failure.
     :returns: a retry decorator.
     """
 
@@ -70,8 +118,13 @@ def retry(exceptions=Exception, tries=-1, delay=0, max_delay=None, backoff=1, ji
     def retry_decorator(f, *fargs, **fkwargs):
         args = fargs if fargs else list()
         kwargs = fkwargs if fkwargs else dict()
-        return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter,
-                                logger)
+        pf = partial(f, *args, **kwargs)
+        if generator:
+            return __retry_internal_generator(pf, exceptions, tries, delay, max_delay, backoff, jitter,
+                                              logger)
+        else:
+            return __retry_internal(pf, exceptions, tries, delay, max_delay, backoff, jitter,
+                                    logger)
 
     return retry_decorator
 
@@ -99,3 +152,30 @@ def retry_call(f, fargs=None, fkwargs=None, exceptions=Exception, tries=-1, dela
     args = fargs if fargs else list()
     kwargs = fkwargs if fkwargs else dict()
     return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter, logger)
+
+
+def retry_generator(f, fargs=None, fkwargs=None, exceptions=Exception, tries=-1, delay=0, max_delay=None, backoff=1, jitter=0,
+                    logger=logging_logger):
+    """
+    Return a generator that wraps a generator returned by a given function, retrying from the start on failure.
+
+    :param f: the function that returns a generator
+    :param fargs: the positional arguments of the function to execute.
+    :param fkwargs: the named arguments of the function to execute.
+    :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
+    :param tries: the maximum number of attempts. default: -1 (infinite).
+    :param delay: initial delay between attempts. default: 0.
+    :param max_delay: the maximum value of delay. default: None (no limit).
+    :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
+    :param jitter: extra seconds added to delay between attempts. default: 0.
+                   fixed if a number, random if a range tuple (min, max)
+    :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
+                   default: retry.logging_logger. if None, logging is disabled.
+    :returns: the result of the f function.
+    """
+    args = fargs if fargs else list()
+    kwargs = fkwargs if fkwargs else dict()
+    return __retry_internal_generator(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter, logger)
+
+
+


### PR DESCRIPTION
Added the ability to provide retry logic for a function that is a generator (uses `yield`). This addition to README.rst:

```
vals = [RuntimeError(0), 1, 2, RuntimeError(3), 4]

@retry(generator=True)
def make_trouble():
    for v in vals:
        if isinstance(v, BaseException):
            vals.remove(v)
            raise v
        else:
            yield v

if __name__ == '__main__':
    # [1, 2, 1, 2, 4]
    # Actually:
    # <Initial call>
    # <New call due to RuntimeError(0)>
    # 1, 2
    # <New call due to RuntimeError(3)>
    # 1, 2, 4
    print([x for x in make_trouble()])
```

Can be thought of as simulating a generator that is connecting to a third party service with intermittent failures (`RuntimeError(0)` after receiving `1, 2`, followed by `RuntimeError(3)` after restarting and retrieving `1, 2, 4`). This allows for graceful retrying, allowing the user of the generator to be responsible for handling duplicates.

The use of an optional parameter `generator=False` on the decorator is meant to be fully backwards compatible.