### PR TITLE
Improve docs to specify delay units

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,8 @@ retry decorator
 
         :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
         :param tries: the maximum number of attempts. default: -1 (infinite).
-        :param delay: initial delay between attempts. default: 0.
-        :param max_delay: the maximum value of delay. default: None (no limit).
+        :param delay: initial delay between attempts (in seconds). default: 0.
+        :param max_delay: the maximum value of delay (in seconds). default: None (no limit).
         :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
         :param jitter: extra seconds added to delay between attempts. default: 0.
                        fixed if a number, random if a range tuple (min, max)
@@ -117,8 +117,8 @@ retry_call
         :param fkwargs: the named arguments of the function to execute.
         :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
         :param tries: the maximum number of attempts. default: -1 (infinite).
-        :param delay: initial delay between attempts. default: 0.
-        :param max_delay: the maximum value of delay. default: None (no limit).
+        :param delay: initial delay between attempts (in seconds). default: 0.
+        :param max_delay: the maximum value of delay (in seconds). default: None (no limit).
         :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
         :param jitter: extra seconds added to delay between attempts. default: 0.
                        fixed if a number, random if a range tuple (min, max)

--- a/retry/api.py
+++ b/retry/api.py
@@ -18,8 +18,8 @@ def __retry_internal(f, exceptions=Exception, tries=-1, delay=0, max_delay=None,
     :param f: the function to execute.
     :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
     :param tries: the maximum number of attempts. default: -1 (infinite).
-    :param delay: initial delay between attempts. default: 0.
-    :param max_delay: the maximum value of delay. default: None (no limit).
+    :param delay: initial delay between attempts (in seconds). default: 0.
+    :param max_delay: the maximum value of delay (in seconds). default: None (no limit).
     :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
     :param jitter: extra seconds added to delay between attempts. default: 0.
                    fixed if a number, random if a range tuple (min, max)
@@ -56,8 +56,8 @@ def retry(exceptions=Exception, tries=-1, delay=0, max_delay=None, backoff=1, ji
 
     :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
     :param tries: the maximum number of attempts. default: -1 (infinite).
-    :param delay: initial delay between attempts. default: 0.
-    :param max_delay: the maximum value of delay. default: None (no limit).
+    :param delay: initial delay between attempts (in seconds). default: 0.
+    :param max_delay: the maximum value of delay (in seconds). default: None (no limit).
     :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
     :param jitter: extra seconds added to delay between attempts. default: 0.
                    fixed if a number, random if a range tuple (min, max)
@@ -87,8 +87,8 @@ def retry_call(f, fargs=None, fkwargs=None, exceptions=Exception, tries=-1, dela
     :param fkwargs: the named arguments of the function to execute.
     :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
     :param tries: the maximum number of attempts. default: -1 (infinite).
-    :param delay: initial delay between attempts. default: 0.
-    :param max_delay: the maximum value of delay. default: None (no limit).
+    :param delay: initial delay between attempts (in seconds). default: 0.
+    :param max_delay: the maximum value of delay (in seconds). default: None (no limit).
     :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
     :param jitter: extra seconds added to delay between attempts. default: 0.
                    fixed if a number, random if a range tuple (min, max)


### PR DESCRIPTION
`delay` and `max_delay` are in seconds, however that wasn't clear from the documentation.