### PR TITLE
Float args delay backoff jitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ sdist/
 target/
 var/
 __pycache__/
+
+# Environments
+venv/

--- a/README.rst
+++ b/README.rst
@@ -38,15 +38,15 @@ retry decorator
 
 .. code:: python
 
-    def retry(exceptions=Exception, tries=-1, delay=0, max_delay=None, backoff=1, jitter=0, logger=logging_logger):
+    def retry(exceptions=Exception, tries=-1, delay=0.0, max_delay=None, backoff=1.0, jitter=0.0, logger=logging_logger):
         """Return a retry decorator.
 
         :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
         :param tries: the maximum number of attempts. default: -1 (infinite).
-        :param delay: initial delay between attempts. default: 0.
+        :param delay: initial delay (seconds) between attempts. default: 0.0 seconds.
         :param max_delay: the maximum value of delay. default: None (no limit).
-        :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
-        :param jitter: extra seconds added to delay between attempts. default: 0.
+        :param backoff: multiplier applied to delay between attempts. default: 1.0 (no backoff).
+        :param jitter: extra seconds added to delay between attempts. default: 0.0 seconds.
                        fixed if a number, random if a range tuple (min, max)
         :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
                        default: retry.logging_logger. if None, logging is disabled.
@@ -106,8 +106,8 @@ retry_call
 
 .. code:: python
 
-    def retry_call(f, fargs=None, fkwargs=None, exceptions=Exception, tries=-1, delay=0, max_delay=None, backoff=1,
-                   jitter=0,
+    def retry_call(f, fargs=None, fkwargs=None, exceptions=Exception, tries=-1, delay=0.0, max_delay=None, backoff=1.0,
+                   jitter=0.0,
                    logger=logging_logger):
         """
         Calls a function and re-executes it if it failed.
@@ -117,10 +117,10 @@ retry_call
         :param fkwargs: the named arguments of the function to execute.
         :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
         :param tries: the maximum number of attempts. default: -1 (infinite).
-        :param delay: initial delay between attempts. default: 0.
+        :param delay: initial delay (seconds) between attempts. default: 0.0 seconds.
         :param max_delay: the maximum value of delay. default: None (no limit).
-        :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
-        :param jitter: extra seconds added to delay between attempts. default: 0.
+        :param backoff: multiplier applied to delay between attempts. default: 1.0 (no backoff).
+        :param jitter: extra seconds added to delay between attempts. default: 0.0 seconds.
                        fixed if a number, random if a range tuple (min, max)
         :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
                        default: retry.logging_logger. if None, logging is disabled.

--- a/retry/api.py
+++ b/retry/api.py
@@ -10,7 +10,7 @@ from .compat import decorator
 logging_logger = logging.getLogger(__name__)
 
 
-def __retry_internal(f, exceptions=Exception, tries=-1, delay=0, max_delay=None, backoff=1, jitter=0,
+def __retry_internal(f, exceptions=Exception, tries=-1, delay=0.0, max_delay=None, backoff=1.0, jitter=0.0,
                      logger=logging_logger):
     """
     Executes a function and retries it if it failed.
@@ -18,10 +18,10 @@ def __retry_internal(f, exceptions=Exception, tries=-1, delay=0, max_delay=None,
     :param f: the function to execute.
     :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
     :param tries: the maximum number of attempts. default: -1 (infinite).
-    :param delay: initial delay between attempts. default: 0.
+    :param delay: initial delay (seconds) between attempts. default: 0.0 seconds.
     :param max_delay: the maximum value of delay. default: None (no limit).
-    :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
-    :param jitter: extra seconds added to delay between attempts. default: 0.
+    :param backoff: multiplier applied to delay between attempts. default: 1.0 (no backoff).
+    :param jitter: extra seconds added to delay between attempts. default: 0.0 seconds.
                    fixed if a number, random if a range tuple (min, max)
     :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
                    default: retry.logging_logger. if None, logging is disabled.
@@ -51,15 +51,15 @@ def __retry_internal(f, exceptions=Exception, tries=-1, delay=0, max_delay=None,
                 _delay = min(_delay, max_delay)
 
 
-def retry(exceptions=Exception, tries=-1, delay=0, max_delay=None, backoff=1, jitter=0, logger=logging_logger):
+def retry(exceptions=Exception, tries=-1, delay=0.0, max_delay=None, backoff=1.0, jitter=0.0, logger=logging_logger):
     """Returns a retry decorator.
 
     :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
     :param tries: the maximum number of attempts. default: -1 (infinite).
-    :param delay: initial delay between attempts. default: 0.
+    :param delay: initial delay (seconds) between attempts. default: 0.0 seconds.
     :param max_delay: the maximum value of delay. default: None (no limit).
-    :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
-    :param jitter: extra seconds added to delay between attempts. default: 0.
+    :param backoff: multiplier applied to delay between attempts. default: 1.0 (no backoff).
+    :param jitter: extra seconds added to delay between attempts. default: 0.0 seconds.
                    fixed if a number, random if a range tuple (min, max)
     :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
                    default: retry.logging_logger. if None, logging is disabled.
@@ -76,8 +76,8 @@ def retry(exceptions=Exception, tries=-1, delay=0, max_delay=None, backoff=1, ji
     return retry_decorator
 
 
-def retry_call(f, fargs=None, fkwargs=None, exceptions=Exception, tries=-1, delay=0, max_delay=None, backoff=1,
-               jitter=0,
+def retry_call(f, fargs=None, fkwargs=None, exceptions=Exception, tries=-1, delay=0.0, max_delay=None, backoff=1.0,
+               jitter=0.0,
                logger=logging_logger):
     """
     Calls a function and re-executes it if it failed.
@@ -87,10 +87,10 @@ def retry_call(f, fargs=None, fkwargs=None, exceptions=Exception, tries=-1, dela
     :param fkwargs: the named arguments of the function to execute.
     :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
     :param tries: the maximum number of attempts. default: -1 (infinite).
-    :param delay: initial delay between attempts. default: 0.
+    :param delay: initial delay (seconds) between attempts. default: 0.0 seconds.
     :param max_delay: the maximum value of delay. default: None (no limit).
-    :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
-    :param jitter: extra seconds added to delay between attempts. default: 0.
+    :param backoff: multiplier applied to delay between attempts. default: 1.0 (no backoff).
+    :param jitter: extra seconds added to delay between attempts. default: 0.0 seconds.
                    fixed if a number, random if a range tuple (min, max)
     :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
                    default: retry.logging_logger. if None, logging is disabled.


### PR DESCRIPTION
I use `retry` and also use [`mypy`](https://github.com/python/mypy) in Python 3.8.

When running `mypy`, it warns about type incompatibilities between `float` and `int` when using `retry_call`.

```none
error: Argument "delay" to "retry_call" has incompatible type "float"; expected "int"  [arg-type]
error: Argument "backoff" to "retry_call" has incompatible type "float"; expected "int"  [arg-type]
```

When looking at the source, I realized it the `delay`, `backhoff`, `jitter`, and `max_delay` params can be `float` or `int`.  These are duck type compatible (why?  read [`mypy` docs here](https://mypy.readthedocs.io/en/stable/duck_type_compatibility.html#duck-type-compatibility)), so the default arg should be a `float` type.

This PR does a few things:
- Change default arg types from `int` to `float`
- Updated in docstrings and `README.rst` to match

**Aside**

- Added `venv` to `.gitignore` from per [here](https://github.com/github/gitignore/blob/master/Python.gitignore#L107) for developer convenience