### PR TITLE
remove mock

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
-mock
 pbr
 pytest
 tox


### PR DESCRIPTION
The mock module is now part of the Python standard library,
available as unittest.mock in Python 3.3 onwards.